### PR TITLE
Pass empty obj to storage.set, rather than assignment.

### DIFF
--- a/app/modules/core/factories/auth.js
+++ b/app/modules/core/factories/auth.js
@@ -23,7 +23,7 @@
             };
 
             var signOut = function () {
-                storage.set('user') = {};
+                storage.set('user', {});
                 return _auth.signOut();
             };
 


### PR DESCRIPTION
Firefox throws an error when assigning to a method.