### PR TITLE
Create a new object from SVGPoints.

### DIFF
--- a/app/modules/classify/directives/text-tool.js
+++ b/app/modules/classify/directives/text-tool.js
@@ -76,7 +76,12 @@
                         },
 
                         addTempPoint: function (event)  {
-                            this.tempPoint = Annotations.add(_.extend(ClassifyCtrl.svg.$getPoint(event), {
+                            var SVGPoints = ClassifyCtrl.svg.$getPoint(event);
+                            var points = {
+                                x: SVGPoints.x,
+                                y: SVGPoints.y
+                            };
+                            this.tempPoint = Annotations.add(_.extend({}, points, {
                                 type: 'tempText',
                                 temp: true
                             }));


### PR DESCRIPTION
Extending the SVGPoints object in FireFox + Safari results in
TypeError: 'x' getter called on an object that does not implement interface SVGPoint.